### PR TITLE
BugFix: reset unbalanced context states in draw function -MacOS / webkit browsers;

### DIFF
--- a/dansversion.html
+++ b/dansversion.html
@@ -775,13 +775,13 @@
     }
 
     function draw() {
-            // Reset any unbalanced context states
+            // Reset any unbalanced context states for MacOS Strict stack management
             let resetCount = 0;
             while (resetCount < 100) { // Safety limit
                 try {
                     ctx.restore();
                     resetCount++;
-                } catch (e) {
+                } catch (e) { // reset until stack is empty and throws stack underflow or empty the save stack by 100 per frame
                     break;
                 }
             }

--- a/dansversion.html
+++ b/dansversion.html
@@ -775,6 +775,20 @@
     }
 
     function draw() {
+            // Reset any unbalanced context states
+            let resetCount = 0;
+            while (resetCount < 100) { // Safety limit
+                try {
+                    ctx.restore();
+                    resetCount++;
+                } catch (e) {
+                    break;
+                }
+            }
+
+            // Start with a fresh state
+            ctx.save();
+
             // --- BACKGROUND LAYERS ---
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             // Draw wall (upper background)
@@ -810,7 +824,7 @@
             ctx.globalAlpha = 0.85;
             ctx.fillStyle = '#4b371c';
             ctx.beginPath();
-            //ctx.ellipse(canvas.width / 2, desk.y + 8, canvas.width * 0.48 * 0.98, 13, 0, 0, Math.PI * 2);
+            //ctx.ellipse(canvas.width / 2, desk.y + 8, canvas.width * 0.48 * 0.98, 13, 0, Math.PI * 2);
             ctx.fill();
             ctx.restore();
 
@@ -858,8 +872,6 @@
             windowGrad.addColorStop(1, '#fff');
             ctx.fillStyle = windowGrad;
             ctx.fillRect(windowX, windowY, 140, 80);
-
-
 
             // --- Clouds ---
             if (!draw.clouds) {


### PR DESCRIPTION
finally found a fix for a bug that caused webkit based browsers to crash my game.

This is  probably not the best way to do this but due to how short the games are and how little code this requires i think this is the best bet for keeping my game under the 13k limit with minor impact on performance.

before each frame reset the stack up to 100 times to prevent ctx.save sync errors on Apple Webkit based browsers which enforce much stricter stack management.


i dont know why i gave up on branchs 4 and 5 i was just frustrated and was being lazy 